### PR TITLE
Missing "by" parameter throws error

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,8 @@ module.exports = postcss.plugin('postcss-for', function (opts) {
         if (!params[0].match(/(^|[^\w])\$([\w\d-_]+)/) ||
              params[1] !== 'from' ||
              params[3] !== 'to' ||
-             params[5] !== 'by' ^ params[5] === undefined ) {
+             params[5] !== 'by' && params[5] !== undefined ||
+             params[5] === 'by' && params[6] === undefined ) {
             throw rule.error('Wrong loop syntax', { plugin: 'postcss-for' });
         }
 

--- a/test/test.js
+++ b/test/test.js
@@ -61,6 +61,12 @@ describe('postcss-for', function () {
         }).to.throw('<css input>:1:1: Wrong loop syntax');
     });
 
+    it('it throws an error on missing by parameter', function () {
+        expect(function () {
+            test('@for $i from 1 to 3 by { .b-$i { width: $(i)px; } }');
+        }).to.throw('<css input>:1:1: Wrong loop syntax');
+    });
+
     it('it throws an error on wrong range parameters', function () {
         expect(function () {
             test('@for $i from a to c { .b-$i { width: $(i)px; } }');


### PR DESCRIPTION
To my eyes, this looks like a syntax error:

```
@for $i from 1 to 3 by {
  .b-$i { width: $(i)px; }
}
```

The `by` keyword is specified, but the actual number to iterate by has been omitted.

But the current code doesn't throw a syntax error, instead it silently sets the `by` parameter to `1` or `-1`.

This PR throws an error if this syntax error is made. It includes tests.